### PR TITLE
Support for uppercase eszett (ẞ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ When the jekyll site is generated all umlauts will be converted to html.
 ü = &uuml; Ü = &Uuml;
 ä = &auml; Ä = &Auml;
 ö = &ouml; Ö = &Ouml;
-ß = &szlig;
+ß = &szlig; ẞ = &#7838;
 ```
 
 # Installation as plugin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Umlauts Generator for Jekyll
-This generator converts all umlauts äÄöÖüÜ and ß in its correct html equivalent.
+This generator converts all umlauts äÄöÖüÜ and ßẞ in its correct html equivalent.
 When the jekyll site is generated all umlauts will be converted to html.
 ```html
 ü = &uuml; Ü = &Uuml;

--- a/lib/jekyll-umlauts.rb
+++ b/lib/jekyll-umlauts.rb
@@ -2,7 +2,7 @@
 # ü = &uuml; Ü = &Uuml;
 # ä = &auml; Ä = &Auml;
 # ö = &ouml; Ö = &Ouml;
-# ß = &szlig;
+# ß = &szlig; ẞ = &#7838;
 # Author: Arne Gockeln
 # Website: http://www.arnegockeln.com
 module Jekyll
@@ -30,6 +30,7 @@ module Jekyll
       content.gsub!(/ä/, '&auml;')
       content.gsub!(/Ä/, '&Auml;')
       content.gsub!(/ß/, '&szlig;')
+      content.gsub!(/ẞ/, '&#7838;')
 
       content
     end


### PR DESCRIPTION
Adds a gsub which converts instances of ẞ to &#7838;
